### PR TITLE
Fix signed mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bld
+src/tags

--- a/src/wcwidth.c
+++ b/src/wcwidth.c
@@ -65,8 +65,8 @@
 
 
 struct interval {
-    int first;
-    int last;
+    wchar_t first;
+    wchar_t last;
 };
 
 /* auxiliary function for binary search in interval table */


### PR DESCRIPTION
On aarch64 architecture, wchar_t is unsigned, and so there is an error comparing `int` to `wchar_t`