### PR TITLE
Implemented ft_col_count() along with corresponding unit tests

### DIFF
--- a/src/fort.h
+++ b/src/fort.h
@@ -371,6 +371,16 @@ int ft_is_empty(const ft_table_t *table);
 size_t ft_row_count(const ft_table_t *table);
 
 /**
+ * Get number of columns in the table.
+ *
+ * @param table
+ *   Pointer to formatted table.
+ * @return
+ *   Number of columns in the table.
+ */
+size_t ft_col_count(const ft_table_t *table);
+
+/**
  *  Erase range of cells.
  *
  *  Range of cells is determined by 2 points (top-left and bottom-right) (both

--- a/src/fort.hpp
+++ b/src/fort.hpp
@@ -1173,6 +1173,18 @@ public:
     }
 
     /**
+     * Get number of columns in the table.
+     *
+     * @return
+     *   Number of columns in the table.
+     */
+    std::size_t
+    col_count() const noexcept
+    {
+        return ft_col_count(table_);
+    }
+
+    /**
      * Get current cell.
      *
      * @return

--- a/src/fort_impl.c
+++ b/src/fort_impl.c
@@ -233,6 +233,19 @@ size_t ft_row_count(const ft_table_t *table)
     return vector_size(table->rows);
 }
 
+size_t ft_col_count(const ft_table_t *table)
+{
+    assert(table && table->rows);
+    size_t cols_n = 0;
+    size_t rows_n = vector_size(table->rows);
+    for (size_t i = 0; i < rows_n; ++i) {
+        f_row_t *row = VECTOR_AT(table->rows, i, f_row_t *);
+        size_t ncols = columns_in_row(row);
+        cols_n = MAX(cols_n, ncols);
+    }
+    return cols_n;
+}
+
 int ft_erase_range(ft_table_t *table,
                    size_t top_left_row, size_t top_left_col,
                    size_t bottom_right_row, size_t bottom_right_col)

--- a/tests/main_test.c
+++ b/tests/main_test.c
@@ -8,6 +8,7 @@ void test_vector_basic(void);
 void test_vector_stress(void);
 void test_string_buffer(void);
 void test_table_sizes(void);
+void test_table_counts(void);
 void test_table_geometry(void);
 void test_table_basic(void);
 void test_table_copy(void);
@@ -36,6 +37,7 @@ struct test_case wb_test_suite [] = {
     {"test_vector_stress", test_vector_stress},
     {"test_string_buffer", test_string_buffer},
     {"test_table_sizes", test_table_sizes},
+    {"test_table_counts", test_table_counts},
     {"test_table_geometry", test_table_geometry},
     {"test_table_copy", test_table_copy},
 };

--- a/tests/wb_tests/test_table_geometry.c
+++ b/tests/wb_tests/test_table_geometry.c
@@ -51,6 +51,85 @@ void test_table_sizes(void)
 }
 
 
+void test_table_counts(void)
+{
+    ft_table_t *table = ft_create_table();
+    assert_true(table != NULL);
+    assert_true(set_test_props_for_table(table) == FT_SUCCESS);
+
+
+    size_t rows = 0;
+    size_t cols = 0;
+    int empty = 0;
+
+    WHEN("Table is empty") {
+        empty = ft_is_empty(table);
+        rows = ft_row_count(table);
+        cols = ft_col_count(table);
+        assert_true(empty);
+        assert_true(rows == 0);
+        assert_true(cols == 0);
+    }
+
+    WHEN("Insert one cell") {
+        int n = ft_printf(table, "%s", "1");
+        assert_true(n == 1);
+        empty = ft_is_empty(table);
+        rows = ft_row_count(table);
+        cols = ft_col_count(table);
+        assert_true(!empty);
+        assert_true(rows == 1);
+        assert_true(cols == 1);
+    }
+
+    WHEN("Insert two cells in the same row") {
+        int n = ft_printf_ln(table, "%s|%s", "2", "3");
+        assert_true(n == 2);
+        empty = ft_is_empty(table);
+        rows = ft_row_count(table);
+        cols = ft_col_count(table);
+        assert_true(!empty);
+        assert_true(rows == 1);
+        assert_true(cols == 3);
+    }
+
+    WHEN("Insert one cell in the next row") {
+        int status = ft_write(table, "hello");
+        assert_true(FT_IS_SUCCESS(status));
+        empty = ft_is_empty(table);
+        rows = ft_row_count(table);
+        cols = ft_col_count(table);
+        assert_true(!empty);
+        assert_true(rows == 2);
+        assert_true(cols == 3);
+    }
+
+    WHEN("Delete first row") {
+        int status = ft_erase_range(table, 0, 0, 0, DEFAULT_VECTOR_CAPACITY);
+        assert_true(FT_IS_SUCCESS(status));
+        empty = ft_is_empty(table);
+        rows = ft_row_count(table);
+        cols = ft_col_count(table);
+        assert_true(!empty);
+        assert_true(rows == 1);
+        assert_true(cols == 1);
+    }
+
+    WHEN("Delete second/last row") {
+        int status = ft_erase_range(table, 0, 0, 0, DEFAULT_VECTOR_CAPACITY);
+        assert_true(FT_IS_SUCCESS(status));
+        empty = ft_is_empty(table);
+        rows = ft_row_count(table);
+        cols = ft_col_count(table);
+        assert_true(empty);
+        assert_true(rows == 0);
+        assert_true(cols == 0);
+    }
+
+    ft_destroy_table(table);
+}
+
+
 void test_table_geometry(void)
 {
     ft_table_t *table = ft_create_table();


### PR DESCRIPTION
This pairs with the existing ft_row_count() using the same column counting method used elsewhere in the code (i.e., iterate over rows and find the biggest).

Added unit tests for ft_row_count(), ft_col_count(), ft_is_empty(), and use a myriad of insertion methods to increase coverage.

Having ft_col_count() makes it easy to call ft_erase_range(t,0,0,ft_row_count(t), ft_col_count(t)) as a means for erasing the whole table and sets the stage for (i.e., didn't implement) an ft_table_erase(t) that wipes out all rows without going as far as ft_table_destroy().