### PR TITLE
Fix compile error in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ int main(void)
 ```C++
 /* C++ API */
 #include <iostream>
+#include <vector>
 #include "fort.hpp"
 int main(void)
 {


### PR DESCRIPTION
`iostream` doesn't include `vector`, so this does a compile error. I've fixed it.